### PR TITLE
Nudge to set username

### DIFF
--- a/frontend-web/src/App.tsx
+++ b/frontend-web/src/App.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Route, Routes } from '@solidjs/router';
-import { Component, For } from 'solid-js';
+import { Component } from 'solid-js';
 
 import styles from './App.module.css';
 
@@ -7,20 +7,18 @@ import { CoffeeCall } from './coffee-call/coffee-call';
 import { Header, Logo } from './scaffolding/header-and-logo';
 import { Settings } from './settings/settings';
 
-export const App: Component = () => {
-  return (
-    <div class={styles.App}>
-      <Header>
-        <NavLink href="/" end={true} >Main</NavLink>
-        <NavLink href="/settings">Settings</NavLink>
-      </Header>
-      <Logo />
-      <main>
-        <Routes>
-          <Route path="/" component={CoffeeCall}/>
-          <Route path="/settings" component={Settings}/>
-        </Routes>
-      </main>
-    </div>
-  );
-};
+export const App: Component = () => (
+  <div class={styles.App}>
+    <Header>
+      <NavLink href="/" end={true} >Main</NavLink>
+      <NavLink href="/settings">Settings</NavLink>
+    </Header>
+    <Logo />
+    <main>
+      <Routes>
+        <Route path="/" component={CoffeeCall} />
+        <Route path="/settings" component={Settings} />
+      </Routes>
+    </main>
+  </div>
+);

--- a/frontend-web/src/coffee-call/coffee-call.tsx
+++ b/frontend-web/src/coffee-call/coffee-call.tsx
@@ -1,20 +1,33 @@
-import { Component, For } from 'solid-js';
+import { Component, For, Show } from 'solid-js';
 
 import styles from './coffee-call.module.css';
 import { SocketClient } from './socket-client';
 import { Protocol } from './protocol';
 import { getUsername } from '../shared/persistence';
+import { Link } from '@solidjs/router';
 
 export const CoffeeCall: Component = () => {
   const client = new SocketClient();
   const protocol = new Protocol(client);
 
+  const username = getUsername();
+
   return (
     <>
       <div class={styles.buttonRow}>
-        <button onClick={() => protocol.join(getUsername())}>Join</button>
-        <button onClick={() => protocol.leave(getUsername())}>Leave</button>
-        <button onClick={() => protocol.start(getUsername())}>Start</button>
+        <Show
+          when={username.trim() !== ''}
+          fallback={
+            <>
+              To participate in calls, set your name first.<br/>
+              <em>→ <Link href="/settings">Settings</Link></em>
+            </>
+          }
+        >
+          <button onClick={() => protocol.join(username)}>Join</button>
+          <button onClick={() => protocol.leave(username)}>Leave</button>
+          <button onClick={() => protocol.start(username)}>Start</button>
+        </Show>
       </div>
       <ul>
         <For each={protocol.messages()}>{(message) =>
@@ -24,4 +37,3 @@ export const CoffeeCall: Component = () => {
     </>
   );
 };
-

--- a/frontend-web/src/scaffolding/header-and-logo.tsx
+++ b/frontend-web/src/scaffolding/header-and-logo.tsx
@@ -6,7 +6,7 @@ import headerStyles from './header.module.css';
 
 export const Header: ParentComponent = (props) =>
   <header class={headerStyles.header}>
-    <h1>CoffeeCaller</h1>
+    <h1>Coffee Caller</h1>
     <nav>
       {props.children}
     </nav>

--- a/frontend-web/src/settings/settings.module.css
+++ b/frontend-web/src/settings/settings.module.css
@@ -1,10 +1,11 @@
+.input {
+  margin-left: .5rem;
+  margin-right: .5rem;
+}
+
 .confirm {
   color: var(--confirm-green);
   width: 0px;
   display: inline-block;
   overflow: visible;
-}
-
-.settings-label .label-text {
-  margin-right: 5px;
 }

--- a/frontend-web/src/settings/settings.tsx
+++ b/frontend-web/src/settings/settings.tsx
@@ -3,13 +3,19 @@ import * as storage from '../shared/persistence';
 
 import style from './settings.module.css';
 
-export const Settings: Component = () => {
-  return <>Settings: <br />
-    <DelayedStoringInput label="Username: " storeValue={storage.storeUsername} getValue={storage.getUsername}/>
-  </>
-}
+export const Settings: Component = () => (
+  <DelayedStoringInput
+    label="Name"
+    storeValue={storage.storeUsername}
+    getValue={storage.getUsername} />
+);
 
-type DelayedStoringInputProps = {label: string, storeValue: (value: string) => void, getValue: () => string, storeDelayInMs?: number};
+type DelayedStoringInputProps = {
+  label: string,
+  storeValue: (value: string) => void,
+  getValue: () => string, storeDelayInMs?: number
+};
+
 const DelayedStoringInput: Component<DelayedStoringInputProps> = (props) => {
   const [value, setValue] = createSignal(props.getValue());
   const [valueStored, setValueStored] = createSignal(false);
@@ -34,6 +40,6 @@ const DelayedStoringInput: Component<DelayedStoringInputProps> = (props) => {
     <input type="text" name="value" value={value()} onInput={handleInput} />
     <Show when={valueStored()}>
       <span class={style.confirm}>✓</span>
-    </Show> 
+    </Show>
   </label>;
 }

--- a/frontend-web/src/settings/settings.tsx
+++ b/frontend-web/src/settings/settings.tsx
@@ -7,7 +7,8 @@ export const Settings: Component = () => (
   <DelayedStoringInput
     label="Name"
     storeValue={storage.storeUsername}
-    getValue={storage.getUsername} />
+    getValue={storage.getUsername}
+  />
 );
 
 type DelayedStoringInputProps = {
@@ -27,7 +28,9 @@ const DelayedStoringInput: Component<DelayedStoringInputProps> = (props) => {
     clearTimeout(storageTimeout);
     storageTimeout = window.setTimeout(
       () => {
-        props.storeValue((event.target as HTMLInputElement).value);
+        const value = (event.target as HTMLInputElement).value.trim();
+        if (value === '') { return; }
+        props.storeValue(value);
         setValue(props.getValue());
         setValueStored(true);
       },
@@ -35,9 +38,9 @@ const DelayedStoringInput: Component<DelayedStoringInputProps> = (props) => {
     );
   }
 
-  return <label class={style['settings-label']}>
-    <span class={style['label-text']}>{props.label}</span>
-    <input type="text" name="value" value={value()} onInput={handleInput} />
+  return <label>
+    <span>{props.label}</span>
+    <input class={style.input} type="text" name="value" value={value()} onInput={handleInput} />
     <Show when={valueStored()}>
       <span class={style.confirm}>✓</span>
     </Show>

--- a/frontend-web/src/shared/persistence.ts
+++ b/frontend-web/src/shared/persistence.ts
@@ -1,12 +1,12 @@
 const keys = {
   username: 'username'
-} as const
+} as const;
 
 type ActualKeys = typeof keys[keyof typeof keys];
 
 export const [storeUsername, getUsername] = storeLoadFunctions<string>(keys.username, '');
 
-function storeLoadFunctions<T>(key: ActualKeys, fallback: T): [(value: T)=>void, () =>T] {
+function storeLoadFunctions<T>(key: ActualKeys, fallback: T): [(value: T) => void, () => T] {
   return [
     (value: T) => store<T>(key, value),
     () => load<T>(key) ?? fallback
@@ -19,5 +19,5 @@ function store<T>(key: ActualKeys, value: T) {
 
 function load<T>(key: ActualKeys): T | null {
   const loadedValue = localStorage.getItem(key);
-  return loadedValue == null? null : JSON.parse(loadedValue);
+  return loadedValue == null ? null : JSON.parse(loadedValue);
 }


### PR DESCRIPTION
Main page now hides the action buttons when there is no username set yet. Instead, a helpful message is shown with a link to the settings.

The settings page is also improved a bit: the username input is trimmed and checked if it is an empty string, which is not stored as a username.