### PR TITLE
Remove redundant JSON serialization (web & BE)

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -14,11 +14,15 @@ const io = new Server(httpServer, {
 
 io.on("connection", (socket) => {
     console.log(`Got new connection: ${socket.id}`);
-    socket.on("coffee", (data) => {
-        io.sockets.emit("coffee", JSON.stringify({
-            ...JSON.parse(data),
+
+    socket.on("coffee", (messageIn) => {
+        console.log('← receivced msg:', messageIn);
+        const messageOut = {
+            ...messageIn,
             broadcastAt: new Date().toISOString()
-        }));
+        };
+        console.log('→ broadcast msg:', messageOut);
+        io.sockets.emit("coffee", messageOut);
     });
 });
 

--- a/frontend-mobile/lib/communication/coffee_caller_protocol.dart
+++ b/frontend-mobile/lib/communication/coffee_caller_protocol.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:coffee_caller/communication/models/coffee_caller_message.dart';
 import 'package:coffee_caller/communication/socket_client.dart';
 
 class CoffeeCallerProtocol {
   Stream<ReceivedCoffeeCallerMessage> get messages =>
-      _socketClient.coffeeMessage.map(_decodeRawMessage);
+      _socketClient.coffeeMessage;
 
   CoffeeCallerProtocol({required SocketClient socketClient})
       : _socketClient = socketClient;
@@ -29,10 +28,6 @@ class CoffeeCallerProtocol {
 
   void _send(CoffeeCallerMessageType type, String username) {
     final message = CoffeeCallerMessage(type, username);
-    _socketClient.sendMessage(jsonEncode(message));
-  }
-
-  ReceivedCoffeeCallerMessage _decodeRawMessage(String rawMessage) {
-    return ReceivedCoffeeCallerMessage.fromJson(jsonDecode(rawMessage));
+    _socketClient.sendMessage(message);
   }
 }

--- a/frontend-mobile/test/app_test.dart
+++ b/frontend-mobile/test/app_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:coffee_caller/communication/models/coffee_caller_message.dart';
 import 'package:coffee_caller/communication/socket_client.dart';
 import 'package:coffee_caller/main.dart';
 import 'package:coffee_caller/storage/settings_storage.dart';
@@ -7,11 +8,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class FakeSocketClient extends Fake implements SocketClient {
-  StreamController<String> messageController = StreamController();
+  StreamController<ReceivedCoffeeCallerMessage> messageController =
+      StreamController();
   StreamController<SocketConnectStatus> statusController = StreamController();
 
   @override
-  Stream<String> get coffeeMessage => messageController.stream;
+  Stream<ReceivedCoffeeCallerMessage> get coffeeMessage =>
+      messageController.stream;
 
   @override
   Stream<SocketConnectStatus> connect() => statusController.stream;
@@ -30,15 +33,12 @@ void main() {
     await tester.pumpWidget(App(socketClient: socket));
     await tester.pump();
 
-    socket.messageController.add('''{
-      "type": "join",
-      "name": "Hello World",
-      "broadcastAt": "2022-09-15T07:28:45.119Z"
-    }''');
+    socket.messageController.add(ReceivedCoffeeCallerMessage(
+        CoffeeCallerMessageType.join, 'John', DateTime.now()));
     await tester.pump();
 
     expect(
-      find.textContaining('Hello World joins a coffee call'),
+      find.textContaining('John joins a coffee call'),
       findsOneWidget,
     );
   });

--- a/frontend-web/src/features/call-for-coffee/backend-communication/socket-client.ts
+++ b/frontend-web/src/features/call-for-coffee/backend-communication/socket-client.ts
@@ -1,16 +1,17 @@
 import { Observable, Subject } from 'rxjs';
 import { io, Socket } from 'socket.io-client';
+import { RawCallMessage } from './protocol';
 
 const event = 'coffee';
 
 export class SocketClient {
     private socket: Socket | undefined;
 
-    constructor(private messageSubject = new Subject<string>()) {
+    constructor(private messageSubject = new Subject<RawCallMessage>()) {
         this.connect();
     }
 
-    public get messages(): Observable<string> {
+    public get messages(): Observable<RawCallMessage> {
         return this.messageSubject.asObservable();
     }
 
@@ -31,9 +32,9 @@ export class SocketClient {
         });
     }
 
-    public send(message: string) {
+    public send(obj: object) {
         assertConnected(this.socket);
-        this.socket.emit(event, message);
+        this.socket.emit(event, obj);
     }
 }
 


### PR DESCRIPTION
Socket.IO already is doing serialization internally, so we don't have to do that and can just send and receive objects.

TODO: adapt flutter client